### PR TITLE
change all IndentedJSON to JSON

### DIFF
--- a/src/controllers/dashboard.go
+++ b/src/controllers/dashboard.go
@@ -8,6 +8,6 @@ import (
 
 func Dashboard(context *gin.Context) {
 	userId, _ := context.Get("userId")
-	context.IndentedJSON(http.StatusOK, gin.H{"message": "Welcome to the authenticated route", "userId": userId})
+	context.JSON(http.StatusOK, gin.H{"message": "Welcome to the authenticated route", "userId": userId})
 	context.Abort()
 }

--- a/src/controllers/health.go
+++ b/src/controllers/health.go
@@ -7,5 +7,5 @@ import (
 )
 
 func Health(context *gin.Context) {
-	context.IndentedJSON(http.StatusOK, gin.H{"message": "server is up and running"})
+	context.JSON(http.StatusOK, gin.H{"message": "server is up and running"})
 }

--- a/src/utils/internalServerErrorResponse.go
+++ b/src/utils/internalServerErrorResponse.go
@@ -7,6 +7,6 @@ import (
 )
 
 func InternalServerErrorResponse(context *gin.Context) {
-	context.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "An internal server error occurred"})
+	context.JSON(http.StatusInternalServerError, gin.H{"message": "An internal server error occurred"})
 	context.Abort()
 }

--- a/src/utils/unauthorizedResponse.go
+++ b/src/utils/unauthorizedResponse.go
@@ -7,6 +7,6 @@ import (
 )
 
 func UnauthorizedResponse(context *gin.Context) {
-	context.IndentedJSON(http.StatusUnauthorized, gin.H{"message": "unauthenticated user"})
+	context.JSON(http.StatusUnauthorized, gin.H{"message": "unauthenticated user"})
 	context.Abort()
 }


### PR DESCRIPTION
# Pull Request: Refactor IndentedJSON to JSON

- This pull request refactors all instances of IndentedJSON to JSON as per the Go language Gin documentation.
- IndentedJSON takes up more resources and should not be used in production.
- This change is important for improving the efficiency and performance of the code.
- By using JSON instead of IndentedJSON, we can reduce the amount of resources required to run the code and improve its overall performance.
- This is especially important in production environments where resources are limited and performance is critical.